### PR TITLE
UnSPEEDY STRUCTURE runs

### DIFF
--- a/bigsdb_attributor/structure/config.py
+++ b/bigsdb_attributor/structure/config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-SPEEDY = True
+SPEEDY = False
 
 ADMBURNIN = 500
 BURNIN = 1000


### PR DESCRIPTION
This does the full attribution run, instead of the truncated one for testing