### PR TITLE
UnSPEEDY iSource runs

### DIFF
--- a/bigsdb_attributor/isource/config.py
+++ b/bigsdb_attributor/isource/config.py
@@ -5,7 +5,7 @@ THINNING = 1
 ALPHA = 1
 ISOURCE_RESULTS = 'isource_results'
 
-speedy = True
+speedy = False
 if speedy:
     import logging
     N = 4


### PR DESCRIPTION
This does the full attribution run, instead of the truncated one used for testing.